### PR TITLE
Updating the action to reflect the latest release for Vulnny

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
         go-version: '^1.20'
     - name: Install Vulnny from source
       shell: bash
-      run: go install github.com/tjgurwara99/vulnny@v0.0.1
+      run: go install github.com/tjgurwara99/vulnny@v0.0.2
     - name: Analyse code
       shell: bash
       run: vulnny -o results.sarif ${{ inputs.packages }}


### PR DESCRIPTION
In this PR, we update the version of vulnny used in the action.yml file to `v0.0.2` which is the latest release at the time of writing this.