### PR TITLE
Use the newly release Vulnny CLI for actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
         go-version: '^1.20'
     - name: Install Vulnny from source
       shell: bash
-      run: go install github.com/tjgurwara99/vulnny@v0.0.2
+      run: go install github.com/tjgurwara99/vulnny@v0.0.3
     - name: Analyse code
       shell: bash
       run: vulnny -o results.sarif ${{ inputs.packages }}


### PR DESCRIPTION
Bumping Vulnny CLI to v0.0.3 latest version for use in this action.